### PR TITLE
Allow company number to be provided as a url param

### DIFF
--- a/enrolment/helpers.py
+++ b/enrolment/helpers.py
@@ -22,8 +22,7 @@ companies_house_session = requests.Session()
 
 def store_companies_house_profile_in_session(session, company_number):
     response = CompaniesHouseClient.retrieve_profile(number=company_number)
-    if not response.ok:
-        response.raise_for_status()
+    response.raise_for_status()
     details = response.json()
     session[COMPANIES_HOUSE_PROFILE_SESSION_KEY] = {
         'company_name': details['company_name'],

--- a/enrolment/tests/test_forms.py
+++ b/enrolment/tests/test_forms.py
@@ -191,12 +191,10 @@ def test_company_export_status_form_validars():
 
 def test_serialize_enrolment_forms():
     actual = forms.serialize_enrolment_forms({
-        'name': 'Extreme Corp',
         'company_number': '01234567',
         'export_status': 'YES',
     })
     expected = {
-        'company_name': 'Extreme Corp',
         'company_number': '01234567',
         'export_status': 'YES',
     }

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -6,6 +6,7 @@ from enrolment.views import (
     CompaniesHouseSearchApiView,
     DomesticLandingView,
     EnrolmentInstructionsView,
+    EnrolmentSingleStepView,
     EnrolmentView,
 )
 from company.views import (
@@ -50,6 +51,11 @@ urlpatterns = [
         r'^register$',
         EnrolmentInstructionsView.as_view(),
         name='register-instructions'
+    ),
+    url(
+        r'^register/single/$',
+        EnrolmentSingleStepView.as_view(),
+        name='register-single-step'
     ),
     url(
         r'^register/(?P<step>.+)$',


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-1348)

![image](https://cloud.githubusercontent.com/assets/5485798/25922503/5c08fd62-35d1-11e7-83bd-b97aaec443c3.png)

In a follow-up task, we will make the landing page form to redirect to `http://buyer.trade.great.dev:8001/register/single/?company_number=<company_number>` once it determines the company has not been registered yet.

The code will then detect the company number is provided and go straight to step three.