### PR TITLE
Check company number is unique on landing page

### DIFF
--- a/enrolment/forms.py
+++ b/enrolment/forms.py
@@ -165,6 +165,17 @@ class CompaniesHouseSearchForm(forms.Form):
     term = forms.CharField()
 
 
+class CompanyNumberForm(IndentedInvalidFieldsMixin, forms.Form):
+    company_number = fields.PaddedCharField(
+        validators=helpers.halt_validation_on_failure(
+            shared_validators.company_number,
+            validators.company_unique,
+        ),
+        max_length=8,
+        fillchar='0',
+    )
+
+
 def serialize_enrolment_forms(cleaned_data):
     """
     Return the shape directory-api-client expects for enrolment.

--- a/enrolment/templates/register-company-number-form.html
+++ b/enrolment/templates/register-company-number-form.html
@@ -1,10 +1,12 @@
 {% load trans from i18n %}
 
-<form class="register-company-number-form" method="post" action="{% url 'register' step='company-number' %}">
-	<input name="enrolment_view-current_step" type="hidden" value="company-number">
+<form class="register-company-number-form" method="post" action="">
+	<input id="id_company_number" name="company_number" type="hidden" value="">
+
 	<label for="id_company_number">
-		<span class="label">{% trans "Enter your company number" %}</span>
-		<input name="company-number-company_number" class="text" type="text" placeholder="{% trans 'Companies House number' %}" />
+		{{ form.company_number.errors }}
+		<span class="label">{% trans "Enter your company name" %}</span>
+		<input name="company_name" class="text" type="text" placeholder="{% trans 'Companies name' %}" />
 	</label>
 	<input class="button button-primary" type="submit" value="{% trans 'Get promoted' %}" />
 </form>

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ test_requirements:
 
 API_CLIENT_ENV_VARS := API_SIGNATURE_SECRET=debug API_CLIENT_BASE_URL=http://debug
 FLAKE8 := flake8 . --exclude=migrations,.venv
-PYTEST := pytest . --cov=. --cov-config=.coveragerc --capture=no $(pytest_args)
+PYTEST := pytest . --cov-config=.coveragerc --capture=no $(pytest_args)
 COLLECT_STATIC := python manage.py collectstatic --noinput
 
 test:
@@ -102,7 +102,7 @@ DEBUG_SET_ENV_VARS := \
 	export SSO_REDIRECT_FIELD_NAME=next; \
 	export SSO_SESSION_COOKIE=debug_sso_session_cookie; \
 	export SESSION_COOKIE_SECURE=false; \
-	export COMPANIES_HOUSE_API_KEY=debug; \
+	export COMPANIES_HOUSE_API_KEY=Jf94CNSpa-p5nKiLipopAhMAgE4YW6eG4f3wIDP8; \
 	export FEATURE_PUBLIC_PROFILES_ENABLED=true; \
 	export SUPPLIER_CASE_STUDY_URL=http://supplier.trade.great.dev:8005/case-study/{id}; \
 	export SUPPLIER_PROFILE_LIST_URL=http://supplier.trade.great.dev:8005/suppliers?sectors={sectors}; \

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ test_requirements:
 
 API_CLIENT_ENV_VARS := API_SIGNATURE_SECRET=debug API_CLIENT_BASE_URL=http://debug
 FLAKE8 := flake8 . --exclude=migrations,.venv
-PYTEST := pytest . --cov-config=.coveragerc --capture=no $(pytest_args)
+PYTEST := pytest . --cov=. --cov-config=.coveragerc --capture=no $(pytest_args)
 COLLECT_STATIC := python manage.py collectstatic --noinput
 
 test:
@@ -102,7 +102,7 @@ DEBUG_SET_ENV_VARS := \
 	export SSO_REDIRECT_FIELD_NAME=next; \
 	export SSO_SESSION_COOKIE=debug_sso_session_cookie; \
 	export SESSION_COOKIE_SECURE=false; \
-	export COMPANIES_HOUSE_API_KEY=Jf94CNSpa-p5nKiLipopAhMAgE4YW6eG4f3wIDP8; \
+	export COMPANIES_HOUSE_API_KEY=debug; \
 	export FEATURE_PUBLIC_PROFILES_ENABLED=true; \
 	export SUPPLIER_CASE_STUDY_URL=http://supplier.trade.great.dev:8005/case-study/{id}; \
 	export SUPPLIER_PROFILE_LIST_URL=http://supplier.trade.great.dev:8005/suppliers?sectors={sectors}; \


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-1347)

The landing page now checks the company number is not yet used, then redirects the user to the registration page.

non-logged in users will be taken to SSO, then sent back to the registration page.

Both logged-in and non-logged-in users will be sent to the third step.