### PR TITLE
Add CSRF protection to the company search endpoint

### DIFF
--- a/enrolment/tests/test_views.py
+++ b/enrolment/tests/test_views.py
@@ -253,7 +253,7 @@ def test_companies_house_search_feature_flag_disabled(client, settings):
 
 def test_companies_house_search_validation_error(client):
     url = reverse('api-internal-companies-house-search')
-    response = client.get(url)  # notice absense of `term`
+    response = client.post(url)  # notice absense of `term`
 
     assert response.status_code == 400
 
@@ -266,7 +266,7 @@ def test_companies_house_search_api_error(
     url = reverse('api-internal-companies-house-search')
 
     with pytest.raises(requests.exceptions.HTTPError):
-        client.get(url, data={'term': 'thing'})
+        client.post(url, data={'term': 'thing'})
 
 
 @patch('enrolment.helpers.CompaniesHouseClient.search')
@@ -276,7 +276,7 @@ def test_companies_house_search_api_success(
     mock_search.return_value = api_response_companies_house_search_200
     url = reverse('api-internal-companies-house-search')
 
-    response = client.get(url, data={'term': 'thing'})
+    response = client.post(url, data={'term': 'thing'})
 
     assert response.status_code == 200
     assert response.content == b'[{"name": "Smashing corp"}]'

--- a/enrolment/views.py
+++ b/enrolment/views.py
@@ -207,8 +207,8 @@ class CompaniesHouseSearchApiView(View):
             raise Http404()
         return super().dispatch(*args, **kwargs)
 
-    def get(self, request, *args, **kwargs):
-        form = self.form_class(data=request.GET)
+    def post(self, request, *args, **kwargs):
+        form = self.form_class(data=request.POST)
         if not form.is_valid():
             return JsonResponse(form.errors, status=400)
         api_response = helpers.CompaniesHouseClient.search(

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
-from django.views.decorators.cache import cache_page
 from django.views.decorators.http import require_http_methods
+from django.views.decorators.csrf import csrf_protect
 
 from enrolment.views import (
     CompaniesHouseSearchApiView,
@@ -27,7 +27,6 @@ from company import proxy as company_proxies
 from admin.proxy import AdminProxyView
 
 
-cache_me = cache_page(60 * 1)
 require_get = require_http_methods(['GET'])
 
 
@@ -134,7 +133,7 @@ urlpatterns = [
     ),
     url(
         r'^api/internal/companies-house-search/$',
-        CompaniesHouseSearchApiView.as_view(),
+        csrf_protect(CompaniesHouseSearchApiView.as_view()),
         name='api-internal-companies-house-search'
     ),
 ]


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-1362)

We're adding this protection to reduce the risk of people abusing our endpoint and affecting our Companies House rate limiting quota.

CSRF protection only applies to requests deemed [unsafe according to RFC 7231](https://github.com/django/django/blob/master/django/middleware/csrf.py#L211). GET is safe. POST is not, hence to trigger CSRF protection we need the endpoint accepted method to be `POST`, not `GET`.

Its not very semantic to have use a POST request to retrieve data, but...pragmatism.