### PR TITLE
Fix empty keywords

### DIFF
--- a/company/helpers.py
+++ b/company/helpers.py
@@ -66,6 +66,7 @@ def get_company_list_from_response(response):
 def format_company_details(details):
     date_of_creation = format_date_of_creation(details.get('date_of_creation'))
     case_studies = map(format_case_study, details['supplier_case_studies'])
+    keywords = details['keywords']
     return {
         'website': details['website'],
         'description': details['description'],
@@ -75,7 +76,7 @@ def format_company_details(details):
         'sectors': pair_sector_values_with_label(details['sectors']),
         'logo': details['logo'],
         'name': details['name'],
-        'keywords': tokenize_keywords(details['keywords']),
+        'keywords': tokenize_keywords(keywords) if keywords else [],
         'employees': get_employees_label(details['employees']),
         'supplier_case_studies': list(case_studies),
         'modified': format_date_modified(details['modified']),

--- a/company/templates/company-private-profile-detail.html
+++ b/company/templates/company-private-profile-detail.html
@@ -291,8 +291,7 @@
 								<strong>Edit</strong>
 							</a>
 							{% for keyword in company.keywords %}
-								{% if not forloop.first %}<span> </span>{% endif %}
-								<a href="{{ SUPPLIER_SEARCH_URL }}?term={{ keyword }}" targe="_blank" class="ed-keyword">{{ keyword }}</a>
+								<a href="{{ SUPPLIER_SEARCH_URL }}?term={{ keyword }}" target="_self" class="ed-keyword">{{ keyword }}</a>{% if not forloop.last %}, {% endif %}
 							{% empty %}
 								<p><a href="{% url show_wizard_links|yesno:'company-edit,company-edit-key-facts' %}">Add keywords</a></p>
 							{% endfor %}

--- a/company/tests/test_helpers.py
+++ b/company/tests/test_helpers.py
@@ -210,3 +210,12 @@ def test_chunk_list_empty():
     input_list = []
     expected_list = []
     assert helpers.chunk_list(input_list, 3) == expected_list
+
+
+def test_format_company_details_handles_keywords_empty(retrieve_profile_data):
+    for value in ['', None, []]:
+        retrieve_profile_data['keywords'] = value
+
+        formatted = helpers.format_company_details(retrieve_profile_data)
+
+        assert formatted['keywords'] == []

--- a/makefile
+++ b/makefile
@@ -57,7 +57,7 @@ DOCKER_SET_DEBUG_ENV_VARS := \
 	export DIRECTORY_UI_BUYER_DIRECTORY_EXTERNAL_API_SIGNATURE_SECRET=debug; \
 	export DIRECTORY_UI_BUYER_NEW_LANDING_PAGE_FEATURE_ENABLED=true;\
 	export DIRECTORY_UI_BUYER_CORS_ORIGIN_ALLOW_ALL=true; \
-	export DIRECTORY_UI_BUYER_SUPPLIER_SEARCH_URL=http://supplier.trade.great.dev:8005
+	export DIRECTORY_UI_BUYER_SUPPLIER_SEARCH_URL=http://supplier.trade.great.dev:8005/search
 
 
 DOCKER_REMOVE_ALL := \
@@ -115,7 +115,7 @@ DEBUG_SET_ENV_VARS := \
 	export DIRECTORY_EXTERNAL_API_SIGNATURE_SECRET=debug; \
 	export NEW_LANDING_PAGE_FEATURE_ENABLED=true; \
 	export CORS_ORIGIN_ALLOW_ALL=true; \
-	export SUPPLIER_SEARCH_URL=http://supplier.trade.great.dev:8005
+	export SUPPLIER_SEARCH_URL=http://supplier.trade.great.dev:8005/search
 
 
 debug_webserver:


### PR DESCRIPTION
Currently, empty keywords is tokenised to `['']`. This prevents `{% empty %}` from being activated in the template.