### PR TITLE
Fix proxy urls

### DIFF
--- a/company/proxy.py
+++ b/company/proxy.py
@@ -10,7 +10,7 @@ class APIViewProxy(BaseProxyView):
     # setting forwarded_host header cause image returned to use FAB's domain
     set_forwarded_host_header = False
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request, path, *args, **kwargs):
         if signature.external_api_checker.test_signature(request) is False:
             return HttpResponseForbidden()
-        return super().dispatch(request, path='', *args, **kwargs)
+        return super().dispatch(request, path, *args, **kwargs)

--- a/company/tests/test_proxy.py
+++ b/company/tests/test_proxy.py
@@ -6,31 +6,43 @@ import urllib3
 
 from django.core.urlresolvers import reverse
 
-view_names = (
-    ('api-external-company', ),
-    ('api-external-supplier',)
+
+supplier_company_url = reverse(
+    'api-external-company', kwargs={'path': '/supplier/company/'}
+)
+supplier_url = reverse(
+    'api-external-supplier', kwargs={'path': '/external/supplier/'}
+)
+supplier_sso_url = reverse(
+    'api-external-supplier-sso', kwargs={'path': '/external/supplier-sso/'}
+)
+
+urls = (
+    supplier_company_url, supplier_url, supplier_sso_url,
 )
 
 test_names = (
     'external company view',
-    'external supplier view'
+    'external supplier view',
+    'external sso id view',
+
 )
 
 
-@pytest.mark.parametrize(('view_name',), view_names, ids=test_names)
-def test_proxy_api_view_bad_signature(view_name, client):
+@pytest.mark.parametrize('url', urls, ids=test_names)
+def test_proxy_api_view_bad_signature(url, client):
     with patch(
             'ui.signature.external_api_checker.test_signature'
     ) as mock_test_signature:
         mock_test_signature.return_value = False
 
-        response = client.get(reverse(view_name))
+        response = client.get(url)
 
         assert response.status_code == http.client.FORBIDDEN
 
 
-@pytest.mark.parametrize(('view_name',), view_names, ids=test_names)
-def test_proxy_api_view_rejects_unsafe_methods(view_name, client):
+@pytest.mark.parametrize('url', urls, ids=test_names)
+def test_proxy_api_view_rejects_unsafe_methods(url, client):
     with patch(
             'ui.signature.external_api_checker.test_signature'
     ) as mock_test_signature:
@@ -39,12 +51,12 @@ def test_proxy_api_view_rejects_unsafe_methods(view_name, client):
         unsafe_methods = [client.delete, client.post, client.patch, client.put]
 
         for unsafe_method in unsafe_methods:
-            response = unsafe_method(reverse(view_name))
+            response = unsafe_method(url)
             assert response.status_code == http.client.METHOD_NOT_ALLOWED
 
 
-@pytest.mark.parametrize(('view_name',), view_names, ids=test_names)
-def test_proxy_api_view_accepts_get(view_name, client):
+@pytest.mark.parametrize('url', urls, ids=test_names)
+def test_proxy_api_view_accepts_get(url, client):
     with patch(
             'ui.signature.external_api_checker.test_signature'
     ) as mock_test_signature, patch(
@@ -58,7 +70,7 @@ def test_proxy_api_view_accepts_get(view_name, client):
             status=http.client.OK,
         )
 
-        response = client.get(reverse(view_name))
+        response = client.get(url)
 
         assert response.json() == proxied_content
         assert 'X-Forwarded-Host' not in mock_urlopen.call_args[1]['headers']

--- a/proxy/views.py
+++ b/proxy/views.py
@@ -18,14 +18,14 @@ class BaseProxyView(ProxyView):
 
         super(BaseProxyView, self).__init__(*args, **kwargs)
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request, path, *args, **kwargs):
         self.request_headers = self.get_request_headers()
 
         redirect_to = self._format_path_to_redirect(request)
         if redirect_to:
             return redirect(redirect_to)
 
-        upstream_response = self.get_upstream_response(request)
+        upstream_response = self.get_upstream_response(request, path)
 
         self._replace_host_on_redirect_location(request, upstream_response)
         self._set_content_type(request, upstream_response)
@@ -42,12 +42,12 @@ class BaseProxyView(ProxyView):
     def get_upstream(self):
         return super(BaseProxyView, self).get_upstream(path=None)
 
-    def get_upstream_response(self, request, *args, **kwargs):
+    def get_upstream_response(self, request, path, *args, **kwargs):
         request_payload = request.body
 
         self.log.debug("Request headers: %s", self.request_headers)
 
-        request_url = self.get_upstream() + request.get_full_path()
+        request_url = self.get_upstream() + path
 
         self.log.debug("Request URL: %s", request_url)
 

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -117,19 +117,19 @@ urlpatterns = [
         name='unsubscribe'
     ),
     url(
-        r'^api/external/supplier/company/$',
+        r'^api/external(?P<path>/supplier/company/)$',
         require_get(company_proxies.APIViewProxy.as_view()),
         name='api-external-company'
     ),
     url(
-        r'^api/external/supplier/$',
+        r'^api(?P<path>/external/supplier/)$',
         require_get(company_proxies.APIViewProxy.as_view()),
         name='api-external-supplier'
     ),
     url(
-        r'^api/external/supplier-sso/$',
+        r'^api(?P<path>/external/supplier-sso/)$',
         require_get(company_proxies.APIViewProxy.as_view()),
-        name='api-external-supplier'
+        name='api-external-supplier-sso'
     ),
     url(
         r'^api/internal/companies-house-search/$',


### PR DESCRIPTION
This change coincides with an API PR I'm making, which changes api's urls.py to be more specific by adding a caret to the start of the "external" urls, for perfect matching - rather than the fluffy "route to this url if the request path ends with `x`".

currently in master

- fab `api/external/supplier/` url matches either api's `external/supplier/$` or `supplier/$` depending on order in `urls.py`. This is the source of the bug.
- fab `api/external/supplier/company/` url matched api's `supplier/company/$`
- fab `api/external/supplier-sso/` url matched api's `external/supplier-sso/$`

now, with this change:

 - fab `external/supplier/` url matches api's `^external/supplier/$`
 - fab `supplier/company/` url matches api's `^supplier/company/$`
 - fab `external/supplier-sso/` url matches api's `^external/supplier-sso/$`
