### PR TITLE
Add "verification option" page

### DIFF
--- a/company/conftest.py
+++ b/company/conftest.py
@@ -107,6 +107,14 @@ def api_response_company_profile_200(retrieve_profile_data):
 
 
 @pytest.fixture
+def api_response_company_profile_unverified_200(retrieve_profile_data):
+    response = requests.Response()
+    response.status_code = http.client.OK
+    response.json = lambda: {**retrieve_profile_data, 'is_verified': False}
+    return response
+
+
+@pytest.fixture
 def api_response_company_profile_letter_sent_200(retrieve_profile_data):
     profile_data = deepcopy(retrieve_profile_data)
     profile_data['is_verification_letter_sent'] = True
@@ -190,6 +198,17 @@ def retrieve_profile(api_response_company_profile_200):
     stub = patch(
         'api_client.api_client.company.retrieve_private_profile',
         return_value=api_response_company_profile_200,
+    )
+    stub.start()
+    yield
+    stub.stop()
+
+
+@pytest.fixture
+def retrieve_profile_unverified(api_response_company_profile_unverified_200):
+    stub = patch(
+        'api_client.api_client.company.retrieve_private_profile',
+        return_value=api_response_company_profile_unverified_200,
     )
     stub.start()
     yield

--- a/company/templates/company-profile-detail.html
+++ b/company/templates/company-profile-detail.html
@@ -54,7 +54,7 @@
 				</div>
 				<div class="span4" style="margin-top: 10px;">
 					{% if company.has_valid_address %}
-						<a href="{% url 'confirm-company-address' %}" class="ed-naked-button-error">
+						<a href="{% url 'verify-company-address' %}" class="ed-naked-button-error">
 							Verify your company
 						</a>
 					{% else %}

--- a/company/templates/company-profile-detail.html
+++ b/company/templates/company-profile-detail.html
@@ -53,14 +53,20 @@
 					<p style="font-weight: 400;">Your profile can't be published until your company is verified</p>
 				</div>
 				<div class="span4" style="margin-top: 10px;">
-					{% if company.has_valid_address %}
-						<a href="{% url 'verify-company-address' %}" class="ed-naked-button-error">
+					{% if features.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED %}
+						<a href="{% url 'verify-company-hub' %}" class="ed-naked-button-error">
 							Verify your company
 						</a>
 					{% else %}
-						<a href="{% url 'company-edit-address' %}" class="ed-naked-button-error">
-							Set your address
-						</a>
+						{% if company.has_valid_address %}
+							<a href="{% url 'verify-company-address' %}" class="ed-naked-button-error">
+								Verify your company
+							</a>
+						{% else %}
+							<a href="{% url 'company-edit-address' %}" class="ed-naked-button-error">
+								Set your address
+							</a>
+						{% endif %}
 					{% endif %}
 				</div>
 			</div>

--- a/company/templates/company-verify-hub.html
+++ b/company/templates/company-verify-hub.html
@@ -1,0 +1,16 @@
+{% extends "govuk_layout.html" %}
+
+{% block content %}
+	<ul>
+		<li>
+		{% if company.is_verification_letter_sent %}
+			<a href="{% url 'verify-company-address-confirm' %}">Verify with your address</a>
+		{% else %}
+			<a href="{% url 'verify-company-address' %}">Verify with your address</a>
+		{% endif %}
+		</li>
+		<li>
+			<a href="{% url 'verify-companies-house' %}">Verify with Companies House</a>
+		</li>
+	</ul>
+{%endblock content %}

--- a/company/templates/company-verify.html
+++ b/company/templates/company-verify.html
@@ -1,0 +1,6 @@
+{% extends "govuk_layout.html" %}
+
+{% block content %}
+	<a href="{% url 'verify-company-address' %}">Verify with your address</a>
+	<a href="{% url 'verify-companies-house' %}">Verify with Companies House</a>
+{%endblock content %}

--- a/company/templates/company-verify.html
+++ b/company/templates/company-verify.html
@@ -1,6 +1,0 @@
-{% extends "govuk_layout.html" %}
-
-{% block content %}
-	<a href="{% url 'verify-company-address' %}">Verify with your address</a>
-	<a href="{% url 'verify-companies-house' %}">Verify with Companies House</a>
-{%endblock content %}

--- a/company/tests/test_templates.py
+++ b/company/tests/test_templates.py
@@ -244,3 +244,67 @@ def test_company_profile_unpublished_published():
     html = render_to_string(template_name, context)
 
     assert 'Your company is published' in html
+
+
+def test_company_profile_details_feature_flag_on():
+    template_name = 'company-profile-detail.html'
+    context = {
+        'features': {
+            'FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED': True,
+        },
+        'company': {
+            'description': 'thing',
+            'summary': 'thing',
+            'email_address': 'thing@example.com',
+        },
+    }
+
+    html = render_to_string(template_name, context)
+
+    assert reverse('verify-company-hub') in html
+
+
+def test_company_profile_details_feature_flag_off():
+    template_name = 'company-profile-detail.html'
+    context = {
+        'features': {
+            'FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED': False,
+        },
+        'company': {
+            'description': 'thing',
+            'summary': 'thing',
+            'email_address': 'thing@example.com',
+        },
+    }
+
+    html = render_to_string(template_name, context)
+
+    assert reverse('verify-company-hub') not in html
+
+
+def test_company_verify_hub_letter_sent():
+    template_name = 'company-verify-hub.html'
+    context = {
+        'company': {
+            'is_verification_letter_sent': True,
+        }
+    }
+
+    html = render_to_string(template_name, context)
+
+    assert reverse('verify-company-address-confirm') in html
+    assert reverse('verify-companies-house') in html
+
+
+def test_company_verify_hub_letter_not_sent():
+    template_name = 'company-verify-hub.html'
+    context = {
+        'company': {
+            'is_verification_letter_sent': False,
+        }
+    }
+
+    html = render_to_string(template_name, context)
+
+    assert reverse('verify-company-address') in html
+    assert reverse('verify-companies-house') in html

--- a/company/tests/test_views.py
+++ b/company/tests/test_views.py
@@ -361,7 +361,7 @@ def address_verification_end_to_end(client, address_verification_address_data):
     ]
 
     def inner(case_study_id=''):
-        url = reverse('confirm-company-address')
+        url = reverse('verify-company-address')
         for key, data in data_step_pairs:
             response = client.post(url, data)
         return response
@@ -1411,7 +1411,7 @@ def test_render_next_step_skips_to_done_if_letter_not_sent(
 def test_companies_house_oauth2_feature_flag_disbaled(settings, client):
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = False
 
-    url = reverse('companies-house-oauth2')
+    url = reverse('verify-companies-house')
     response = client.get(url)
 
     assert response.status_code == 404
@@ -1420,20 +1420,20 @@ def test_companies_house_oauth2_feature_flag_disbaled(settings, client):
 def test_companies_house_oauth2_not_logged_in(client, settings):
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = True
 
-    url = reverse('companies-house-oauth2')
+    url = reverse('verify-companies-house')
     response = client.get(url)
 
     assert response.status_code == 302
     assert urllib.parse.unquote_plus(response.get('Location')) == (
         'http://sso.trade.great.dev:8004/accounts/login/?'
-        'next=http://testserver/companies-house-oauth2/'
+        'next=http://testserver/verify/companies-house/'
     )
 
 
 def test_companies_house_oauth2_no_company(settings, no_company_client):
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = True
 
-    url = reverse('companies-house-oauth2')
+    url = reverse('verify-companies-house')
     response = no_company_client.get(url)
 
     assert response.status_code == 302
@@ -1445,7 +1445,7 @@ def test_companies_house_oauth2_has_company_redirects(
 ):
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = True
 
-    url = reverse('companies-house-oauth2')
+    url = reverse('verify-companies-house')
     response = has_company_client.get(url)
 
     assert response.status_code == 302
@@ -1461,7 +1461,7 @@ def test_companies_house_oauth2_has_company_redirects(
 def test_companies_house_callback_feature_flag_disbaled(settings, client):
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = False
 
-    url = reverse('companies-house-oauth2-callback')
+    url = reverse('verify-companies-house-callback')
     response = client.get(url)
 
     assert response.status_code == 404
@@ -1470,7 +1470,7 @@ def test_companies_house_callback_feature_flag_disbaled(settings, client):
 def test_companies_house_callback_not_logged_in(settings, client):
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = True
 
-    url = reverse('companies-house-oauth2-callback')
+    url = reverse('verify-companies-house-callback')
     response = client.get(url)
 
     assert response.status_code == 302
@@ -1483,7 +1483,7 @@ def test_companies_house_callback_not_logged_in(settings, client):
 def test_companies_house_callback_no_company(settings, no_company_client):
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = True
 
-    url = reverse('companies-house-oauth2-callback')
+    url = reverse('verify-companies-house-callback')
     response = no_company_client.get(url)
 
     assert response.status_code == 302
@@ -1496,7 +1496,7 @@ def test_companies_house_callback_missing_code(
 ):
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = True
 
-    url = reverse('companies-house-oauth2-callback')  # missing code
+    url = reverse('verify-companies-house-callback')  # missing code
     response = has_company_client.get(url)
 
     assert response.status_code == 200
@@ -1514,7 +1514,7 @@ def test_companies_house_callback_has_company_calls_companies_house(
     mock_verify_oauth2_code.return_value = api_response_oauth2_verify_200
     mock_verify_with_companies_house.return_value = api_response_200
 
-    url = reverse('companies-house-oauth2-callback')
+    url = reverse('verify-companies-house-callback')
     response = has_company_client.get(url, {'code': '123'})
 
     assert response.status_code == 302
@@ -1543,7 +1543,7 @@ def test_companies_house_callback_invalid_code(
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = True
     mock_verify_oauth2_code.return_value = api_response_400
 
-    url = reverse('companies-house-oauth2-callback')
+    url = reverse('verify-companies-house-callback')
     response = has_company_client.get(url, {'code': '123'})
 
     assert response.status_code == 200
@@ -1558,8 +1558,32 @@ def test_companies_house_callback_unauthorized(
     settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = True
     mock_verify_oauth2_code.return_value = api_response_401
 
-    url = reverse('companies-house-oauth2-callback')
+    url = reverse('verify-companies-house-callback')
     response = has_company_client.get(url, {'code': '123'})
 
     assert response.status_code == 200
     assert b'Invalid code.' in response.content
+
+
+def test_verify_company_feature_flag_on():
+    pass
+
+
+def test_verify_company_feature_flag_off():
+    pass
+
+
+def test_verify_company_anon_user():
+    pass
+
+
+def test_verify_company_authed_user():
+    pass
+
+
+def test_verify_company_no_company_user():
+    pass
+
+
+def test_verify_company_has_company_user():
+    pass

--- a/company/views.py
+++ b/company/views.py
@@ -266,7 +266,10 @@ class CompanyProfileEditView(BaseMultiStepCompanyEditView):
         return context
 
     def handle_profile_update_success(self):
-        if self.condition_show_address():
+        if settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED:
+            if not self.company_profile['is_verified']:
+                return redirect('verify-company-hub')
+        elif self.condition_show_address():
             return TemplateResponse(self.request, self.templates[self.SENT])
         return super().handle_profile_update_success()
 

--- a/company/views.py
+++ b/company/views.py
@@ -225,6 +225,9 @@ class CompanyProfileEditView(BaseMultiStepCompanyEditView):
         return super().render_next_step(form, **kwargs)
 
     def condition_show_address(self):
+        # once this feature flag is removed, this view will never show address
+        if settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED:
+            return False
         return not any([
             self.company_profile['is_verification_letter_sent'],
             self.company_profile['verified_with_preverified_enrolment'],
@@ -318,8 +321,8 @@ class CompanyAddressVerificationView(
         )
 
 
-# once the feature flag is removed, turn this into a RedirectView
-class CompanyAddressVerificationOldView(CompanyAddressVerificationView):
+# TODO: once the feature flag is removed, turn this into a RedirectView
+class CompanyAddressVerificationHistoricView(CompanyAddressVerificationView):
     def dispatch(self, *args, **kwargs):
         if settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED:
             # redirect to the same view, bit with the new url

--- a/ui/context_processors.py
+++ b/ui/context_processors.py
@@ -3,7 +3,11 @@ from django.conf import settings
 
 def feature_flags(request):
     return {
-        'features': {}
+        'features': {
+            'FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED': (
+                settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED
+            )
+        }
     }
 
 

--- a/ui/tests/test_context_processors.py
+++ b/ui/tests/test_context_processors.py
@@ -7,12 +7,15 @@ def test_feature_flags_installed(settings):
     assert 'ui.context_processors.feature_flags' in processors
 
 
-def test_feature_returns_expected_features():
+def test_feature_returns_expected_features(settings):
+    settings.FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED = True
 
     actual = context_processors.feature_flags(None)
 
     assert actual == {
-        'features': {}
+        'features': {
+            'FEATURE_COMPANIES_HOUSE_OAUTH2_ENABLED': True,
+        }
     }
 
 

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -12,6 +12,7 @@ from company.views import (
     CompaniesHouseOauth2CallbackView,
     CompaniesHouseOauth2View,
     CompanyAddressVerificationView,
+    CompanyAddressVerificationOldView,
     CompanyDescriptionEditView,
     CompanyProfileDetailView,
     CompanyProfileEditView,
@@ -24,6 +25,7 @@ from company.views import (
     SupplierCaseStudyWizardView,
     SupplierClassificationEditView,
     SupplierContactEditView,
+    CompanyVerifyView,
 )
 from company import proxy as company_proxies
 from admin.proxy import AdminProxyView
@@ -57,11 +59,6 @@ urlpatterns = [
         r'^register-submit$',
         SubmitEnrolmentView.as_view(),
         name='register-submit'
-    ),
-    url(
-        r'^confirm-company-address$',
-        CompanyAddressVerificationView.as_view(),
-        name='confirm-company-address'
     ),
     url(
         r'^company-profile$',
@@ -118,16 +115,33 @@ urlpatterns = [
         EmailUnsubscribeView.as_view(),
         name='unsubscribe'
     ),
+
     url(
-        r'^companies-house-oauth2/$',
+        r'^verify/$',
+        CompanyVerifyView.as_view(),
+        name='verify-company'
+    ),
+    url(
+        r'^verify/address/$',
+        CompanyAddressVerificationView.as_view(),
+        name='verify-company-address'
+    ),
+    url(
+        r'^verify/companies-house/$',
         CompaniesHouseOauth2View.as_view(),
-        name='companies-house-oauth2'
+        name='verify-companies-house'
     ),
     url(
         r'^companies-house-oauth2-callback/$',
         CompaniesHouseOauth2CallbackView.as_view(),
-        name='companies-house-oauth2-callback'
+        name='verify-companies-house-callback'
     ),
+    url(
+        r'^confirm-company-address$',
+        CompanyAddressVerificationOldView.as_view(),
+        name='verify-company-address-historic-url'
+    ),
+
     url(
         r'^api/external(?P<path>/supplier/company/)$',
         require_get(company_proxies.APIViewProxy.as_view()),

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -12,7 +12,7 @@ from company.views import (
     CompaniesHouseOauth2CallbackView,
     CompaniesHouseOauth2View,
     CompanyAddressVerificationView,
-    CompanyAddressVerificationOldView,
+    CompanyAddressVerificationHistoricView,
     CompanyDescriptionEditView,
     CompanyProfileDetailView,
     CompanyProfileEditView,
@@ -119,7 +119,7 @@ urlpatterns = [
     url(
         r'^verify/$',
         CompanyVerifyView.as_view(),
-        name='verify-company'
+        name='verify-company-hub'
     ),
     url(
         r'^verify/address/$',
@@ -138,7 +138,7 @@ urlpatterns = [
     ),
     url(
         r'^confirm-company-address$',
-        CompanyAddressVerificationOldView.as_view(),
+        CompanyAddressVerificationHistoricView.as_view(),
         name='verify-company-address-historic-url'
     ),
 

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -26,6 +26,7 @@ from company.views import (
     SupplierClassificationEditView,
     SupplierContactEditView,
     CompanyVerifyView,
+    SendVerificationLetterView,
 )
 from company import proxy as company_proxies
 from admin.proxy import AdminProxyView
@@ -122,9 +123,14 @@ urlpatterns = [
         name='verify-company-hub'
     ),
     url(
-        r'^verify/address/$',
-        CompanyAddressVerificationView.as_view(),
+        r'^verify/letter-send$',
+        SendVerificationLetterView.as_view(),
         name='verify-company-address'
+    ),
+    url(
+        r'^verify/letter-confirm/$',
+        CompanyAddressVerificationView.as_view(),
+        name='verify-company-address-confirm'
     ),
     url(
         r'^verify/companies-house/$',


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-2024)

with feature flag on:

- company edit page now no longer has "address" or "confirm address".
- a "verify hub" page has been added, which allows selecting method of verification.
- the verification hub links to "send letter" page if verification letter not yet sent.
- the verification hub links to "input code" page if verification letter has been sent.

with feature flag off:
 - no change