### PR TITLE
Keep export preferences open on page load if not empty

### DIFF
--- a/enrolment/static/javascripts/company-edit.js
+++ b/enrolment/static/javascripts/company-edit.js
@@ -24,7 +24,9 @@
     }
   }
 
-  hideDestinationsOther();
+  if (destinationsOther.value === '') {
+    hideDestinationsOther();
+  }
   hideDestinationOtherLabel();
   destinations.lastChild.addEventListener('change', handleDestinationOtherChange);
 })();


### PR DESCRIPTION
Currently the "other" box is always hidden on page load.

On page load it should only be hidden if the box is empty.