### PR TITLE
Show validation error

### DIFF
--- a/enrolment/static/javascripts/index.js
+++ b/enrolment/static/javascripts/index.js
@@ -360,6 +360,7 @@ GOVUK.components = (new function() {
     }
   }
   SelectiveLookup.prototype.search = function() {
+   this._private.$errors.empty();
    this._private.service.update(this.param());
   }
   SelectiveLookup.prototype.param = function() {
@@ -442,11 +443,6 @@ GOVUK.components = (new function() {
         instance._private.$errors.empty();
         instance._private.$errors.append("<p>Check that you entered the company name correctly and select the matching company name from the list.</p>");
       }
-    });
-    
-    // Clear previously shown errors.
-    this._private.$input.on("focus.CompaniesHouseNameLookup", function(e) {
-      instance._private.$errors.empty();
     });
   }
   CompaniesHouseNameLookup.prototype = new SelectiveLookup;


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-2218)

## The reason it happens:
 - the validation error is cleared on the focus of the input area
 - the input area has `autofocus="autofocus"`, resulting in the input area being focussed on page load

## Reason it was not spotted by devs
 -  `autofocus="autofocus"` does not work if the chrome dev tools is open.