### PR TITLE
Close company selector on click

### DIFF
--- a/enrolment/static/javascripts/index.js
+++ b/enrolment/static/javascripts/index.js
@@ -413,9 +413,6 @@ GOVUK.components = (new function() {
     }
   }
 
-  $(document.body).on("click.SelectiveLookupCloseAll", SelectiveLookup.closeAll);
-
-
   /* Extends SelectiveLookup to perform specific requirements
    * for Companies House company search by name, and resulting
    * form field population.
@@ -503,6 +500,10 @@ GOVUK.page = (new function() {
       // Apply JS lookup functionality.
       new GOVUK.components.CompaniesHouseNameLookup($companyName, $companyNumber);
     });
+    $(document.body).on(
+      "click.SelectiveLookupCloseAll",
+      GOVUK.components.SelectiveLookup.closeAll
+    );
   }
 
 });


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-2306)

Reason it happened: `document.body` does not exist when the js loads.

solution: move the binding of `document.body` to `init()`, which is called once the rest of the page loads.