### PR TITLE
GP2-2437: Fix test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Pre-release
+- NOTICKET - Django version bump to 2.2.22 (security fix)
 - GP2-2437 - fix failing tests due to change in d-components 35.5.0
 - GP2-2381 - corrected footer link for contact 
 ## Hotfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Pre-release
+- GP2-2437 - fix failing tests due to change in d-components 35.5.0
 - GP2-2381 - corrected footer link for contact 
 ## Hotfix
 - NOTICKET - fix-vulnerabilities

--- a/company/tests/test_templates.py
+++ b/company/tests/test_templates.py
@@ -1,29 +1,34 @@
 from django.urls import reverse
 from django.template.loader import render_to_string
 
+from directory_components.context_processors import urls_processor
 
-def test_company_verify_hub_letter_sent():
+
+def test_company_verify_hub_letter_sent(rf):
+    request = rf.get('/')
     template_name = 'company-verify-hub.html'
     context = {
         'company': {
             'is_verification_letter_sent': True,
         }
     }
-
+    context.update(urls_processor(request))
+    assert 'feedback' in context['services_urls']
     html = render_to_string(template_name, context)
-
     assert reverse('verify-company-address-confirm') in html
     assert reverse('verify-companies-house') in html
 
 
-def test_company_verify_hub_letter_not_sent():
+def test_company_verify_hub_letter_not_sent(rf):
+    request = rf.get('/')
     template_name = 'company-verify-hub.html'
     context = {
         'company': {
             'is_verification_letter_sent': False,
         }
     }
-
+    context.update(urls_processor(request))
+    assert 'feedback' in context['services_urls']
     html = render_to_string(template_name, context)
 
     assert reverse('verify-company-address') in html

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django==2.2.20
+django==2.2.22
 django-environ==0.4.5
 django-formtools==2.1
 django-redis==4.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ django-health-check==3.8.0
     # via directory-healthcheck
 django-redis==4.11.0
     # via -r requirements.in
-django==2.2.20
+django==2.2.22
     # via
     #   -r requirements.in
     #   directory-api-client

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -56,7 +56,7 @@ django-health-check==3.8.0
     # via directory-healthcheck
 django-redis==4.11.0
     # via -r requirements.in
-django==2.2.20
+django==2.2.22
     # via
     #   -r requirements.in
     #   directory-api-client


### PR DESCRIPTION
This changeset remedies a failure in both tests from company/tests/test_templates.py

The tests were failing because the entire `content` block from the relevant template was somehow missing.... 🕵️ 

The bug appeared when directory-components was updated to support the V2/Magna header, but the bug was **not** caused by the Magna work. 

Using git-bisect, it turned out to be that the bug came from commit d3f7c8d1c93eee5a4b292c140e5fdf08681a1320 (https://github.com/uktrade/directory-components/commit/d3f7c8d1c93eee5a4b292c140e5fdf08681a1320) which was for d-components v35.5.0

directory-ui-buyer had previously been on directory-components==35.4.0, on which tests pass 100%

The bug itself was only present in tests, and came down to:
* directory-components 35.5.0 moved a template fragment into its own include, for code reuse
* that include made reference to a context variable (services_urls) which was not being provided in the context passed to render_to_string() in the test
* the rendered content was failing to include the expected content because the entire include was blowing up due to the absence of the context vars, whereas it it didn't blow up when it was NOT an included partial

Explicitly including the output of the `urls_processor` context processor fixed the bug in the tests. No app-code change was needed.

Note that the rendered site was not affected by this change - only the tests. Here's the page on Dev (pre-fix of tests) with all the expected content in it:

<img width="1251" alt="Screenshot 2021-05-05 at 14 49 43" src="https://user-images.githubusercontent.com/101457/117152291-cae8c080-adb1-11eb-9026-cae0ee02bbf5.png">




 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
