### PR TITLE
GP2-2375 Redirect next in enrolment to business_profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## Pre-release
+- GP2-2375 - Redirect 'next' in enrolment to business profile
 - NOTICKET - Django version bump to 2.2.22 (security fix)
 - GP2-2437 - fix failing tests due to change in d-components 35.5.0
-- GP2-2381 - corrected footer link for contact 
+- GP2-2381 - corrected footer link for contact
+
 ## Hotfix
 - NOTICKET - fix-vulnerabilities
 - GP2-2332 - added magna header

--- a/enrolment/views.py
+++ b/enrolment/views.py
@@ -18,7 +18,7 @@ class DomesticLandingView(TemplateView):
             return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
-        enrolment_url = (urls.domestic.SINGLE_SIGN_ON_PROFILE / 'enrol/') + '?business-profile-intent=true'
+        enrolment_url = (urls.domestic.SINGLE_SIGN_ON_PROFILE / 'business-profile/')
         if self.request.user.is_anonymous:
             enrolment_url = add_next(
                 destination_url=settings.SSO_PROXY_LOGIN_URL,


### PR DESCRIPTION
Update the 'next' parameter passed to login, to go to business profile on directory-sso-profile after hitting Magna login.
The url of the Magna login url is set as an env var already.

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding CSS) CSS have been compiled.
 - [ ] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
 - [ ] (if changing the UI) Add a printscreen to the PR
