### PR TITLE
KLS-607 - Upgrade redis / replace codecov with pytest-codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,7 @@ jobs:
           command: |
             . venv/bin/activate
             mkdir test-reports
-            make pytest -- --cov=. --cov-config=.coveragerc --cov-report=html --junitxml=test-reports/junit.xml
-            codecov
+            make pytest_codecov -- --codecov-token=${CODECOV_TOKEN}
       - store_test_results:
           path: test-reports
       - store_artifacts:

--- a/makefile
+++ b/makefile
@@ -10,7 +10,6 @@ pytest:
 pytest_codecov:
 	ENV_FILES='test,dev' \
 	pytest \
-		tests/unit \
 		--junit-xml=./results/pytest_unit_report.xml \
 		--cov-config=.coveragerc \
 		--cov-report=html \

--- a/makefile
+++ b/makefile
@@ -7,6 +7,17 @@ clean:
 pytest:
 	ENV_FILES='test,dev' pytest $(ARGUMENTS)
 
+pytest_codecov:
+	ENV_FILES='test,dev' \
+	pytest \
+		tests/unit \
+		--junit-xml=./results/pytest_unit_report.xml \
+		--cov-config=.coveragerc \
+		--cov-report=html \
+		--cov=. \
+		--codecov \
+		$(ARGUMENTS)
+
 manage:
 	ENV_FILES='secrets-do-not-commit,dev' ./manage.py $(ARGUMENTS)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,11 @@ asgiref==3.6.0
     # via django
 async-timeout==4.0.2
     # via redis
-attrs==22.2.0
+attrs==23.1.0
     # via jsonschema
-beautifulsoup4==4.12.0
+beautifulsoup4==4.12.2
     # via directory-components
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   requests
     #   sentry-sdk
@@ -34,7 +34,7 @@ directory-client-core==7.1.1
     #   directory-sso-api-client
 directory-components==39.0.2
     # via -r requirements.in
-directory-constants==23.0.1
+directory-constants==23.0.2
     # via directory-components
 directory-healthcheck==3.0.3
     # via -r requirements.in
@@ -96,7 +96,7 @@ pytz==2021.3
     # via
     #   directory-validators
     #   django
-redis==4.5.4
+redis==4.5.5
     # via django-redis
 requests[security]==2.25.1
     # via
@@ -111,9 +111,9 @@ six==1.16.0
     # via
     #   jsonschema
     #   w3lib
-soupsieve==2.4
+soupsieve==2.4.1
     # via beautifulsoup4
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 urllib3==1.26.15
     # via

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -2,13 +2,13 @@
 
 pip-tools
 pytest>=4.4.0<5.0.0
-pytest-cov==2.7.1
 pytest-django>=3.5.1<4.0.0
 pytest-xdist==1.29.0
 pytest-sugar
 flake8
 requests_mock
 freezegun
-codecov
+pytest-codecov
+GitPython
 py>=1.10.0
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,15 +8,13 @@ asgiref==3.6.0
     # via django
 async-timeout==4.0.2
     # via redis
-attrs==22.2.0
-    # via
-    #   jsonschema
-    #   pytest
-beautifulsoup4==4.12.0
+attrs==23.1.0
+    # via jsonschema
+beautifulsoup4==4.12.2
     # via directory-components
 build==0.10.0
     # via pip-tools
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   requests
     #   sentry-sdk
@@ -26,11 +24,9 @@ chardet==4.0.0
     # via requests
 click==8.1.3
     # via pip-tools
-codecov==2.1.12
-    # via -r requirements_test.in
-coverage==7.2.2
+coverage[toml]==7.2.5
     # via
-    #   codecov
+    #   pytest-codecov
     #   pytest-cov
 cryptography==39.0.1
     # via
@@ -46,7 +42,7 @@ directory-client-core==7.1.1
     #   directory-sso-api-client
 directory-components==39.0.2
     # via -r requirements.in
-directory-constants==23.0.1
+directory-constants==23.0.2
     # via directory-components
 directory-healthcheck==3.0.3
     # via -r requirements.in
@@ -88,6 +84,10 @@ flake8==6.0.0
     # via -r requirements_test.in
 freezegun==1.2.2
     # via -r requirements_test.in
+gitdb==4.0.10
+    # via gitpython
+gitpython==3.1.31
+    # via -r requirements_test.in
 gunicorn==20.0.4
     # via -r requirements.in
 idna==2.10
@@ -104,7 +104,7 @@ monotonic==1.6
     # via directory-client-core
 olefile==0.46
     # via directory-validators
-packaging==23.0
+packaging==23.1
     # via
     #   build
     #   pytest
@@ -113,7 +113,7 @@ pillow==9.3.0
     # via
     #   -r requirements.in
     #   directory-validators
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements_test.in
 pluggy==1.0.0
     # via pytest
@@ -134,21 +134,24 @@ pyproject-hooks==1.0.0
     # via build
 pyrsistent==0.19.3
     # via jsonschema
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements_test.in
+    #   pytest-codecov
     #   pytest-cov
     #   pytest-django
     #   pytest-forked
     #   pytest-sugar
     #   pytest-xdist
-pytest-cov==2.7.1
+pytest-codecov==0.5.1
     # via -r requirements_test.in
+pytest-cov==4.0.0
+    # via pytest-codecov
 pytest-django==4.5.2
     # via -r requirements_test.in
 pytest-forked==1.6.0
     # via pytest-xdist
-pytest-sugar==0.9.6
+pytest-sugar==0.9.7
     # via -r requirements_test.in
 pytest-xdist==1.29.0
     # via -r requirements_test.in
@@ -158,14 +161,14 @@ pytz==2021.3
     # via
     #   directory-validators
     #   django
-redis==4.5.4
+redis==4.5.5
     # via django-redis
 requests[security]==2.25.1
     # via
     #   -r requirements.in
-    #   codecov
     #   directory-api-client
     #   directory-client-core
+    #   pytest-codecov
     #   requests-mock
 requests-mock==1.10.0
     # via -r requirements_test.in
@@ -180,15 +183,18 @@ six==1.16.0
     #   python-dateutil
     #   requests-mock
     #   w3lib
-soupsieve==2.4
+smmap==5.0.0
+    # via gitdb
+soupsieve==2.4.1
     # via beautifulsoup4
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-termcolor==2.2.0
+termcolor==2.3.0
     # via pytest-sugar
 tomli==2.0.1
     # via
     #   build
+    #   coverage
     #   pytest
 urllib3==1.26.15
     # via


### PR DESCRIPTION
This PR bumps redis to 4.5.5 and replaces the codecov package with pytest-codecov.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/jira/software/projects/EAM/boards/359?selectedIssue=KLS-607
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Python requirements have been re-compiled.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
