### PR TITLE
bump urllib3 to 1.26.18

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ directory-api-client==26.4.2
 directory-client-core==7.2.5
 requests[security]==2.31.0
 cryptography==41.0.3
-urllib3>=1.26.*
+urllib3==1.26.18
 djangorestframework==3.11.*
 py>=1.10.0
 pillow==9.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.7.2
     # via django
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via redis
 attrs==23.1.0
     # via jsonschema
@@ -16,9 +16,9 @@ certifi==2023.7.22
     # via
     #   requests
     #   sentry-sdk
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via requests
 cryptography==41.0.3
     # via -r requirements.in
@@ -89,7 +89,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pytz==2023.3
     # via directory-validators
-redis==4.6.0
+redis==5.0.1
     # via django-redis
 requests[security]==2.31.0
     # via
@@ -105,13 +105,13 @@ six==1.16.0
     #   jsonschema
     #   mohawk
     #   w3lib
-soupsieve==2.4.1
+soupsieve==2.5
     # via beautifulsoup4
 sqlparse==0.4.4
     # via django
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via asgiref
-urllib3==1.26.16
+urllib3==1.26.18
     # via
     #   -r requirements.in
     #   directory-validators

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,25 +6,25 @@
 #
 asgiref==3.7.2
     # via django
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via redis
 attrs==23.1.0
     # via jsonschema
 beautifulsoup4==4.12.2
     # via directory-components
-build==0.10.0
+build==1.0.3
     # via pip-tools
 certifi==2023.7.22
     # via
     #   requests
     #   sentry-sdk
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via requests
-click==8.1.6
+click==8.1.7
     # via pip-tools
-coverage[toml]==7.2.7
+coverage[toml]==7.3.2
     # via
     #   pytest-codecov
     #   pytest-cov
@@ -73,7 +73,7 @@ djangorestframework==3.11.2
     # via
     #   -r requirements.in
     #   sigauth
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
@@ -81,14 +81,16 @@ flake8==6.1.0
     # via -r requirements_test.in
 freezegun==1.2.2
     # via -r requirements_test.in
-gitdb==4.0.10
+gitdb==4.0.11
     # via gitpython
-gitpython==3.1.35
+gitpython==3.1.40
     # via -r requirements_test.in
 gunicorn==20.0.4
     # via -r requirements.in
 idna==3.4
     # via requests
+importlib-metadata==6.8.0
+    # via build
 iniconfig==2.0.0
     # via pytest
 jsonschema==3.2.0
@@ -101,7 +103,7 @@ monotonic==1.6
     # via directory-client-core
 olefile==0.46
     # via directory-validators
-packaging==23.1
+packaging==23.2
     # via
     #   build
     #   pytest
@@ -110,16 +112,16 @@ pillow==9.3.0
     # via
     #   -r requirements.in
     #   directory-validators
-pip-tools==7.2.0
+pip-tools==7.3.0
     # via -r requirements_test.in
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 py==1.11.0
     # via
     #   -r requirements.in
     #   -r requirements_test.in
     #   pytest-forked
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via flake8
 pycparser==2.21
     # via cffi
@@ -129,7 +131,7 @@ pyproject-hooks==1.0.0
     # via build
 pyrsistent==0.19.3
     # via jsonschema
-pytest==7.4.0
+pytest==7.4.2
     # via
     #   -r requirements_test.in
     #   pytest-codecov
@@ -154,7 +156,7 @@ python-dateutil==2.8.2
     # via freezegun
 pytz==2023.3
     # via directory-validators
-redis==4.6.0
+redis==5.0.1
     # via django-redis
 requests[security]==2.31.0
     # via
@@ -177,9 +179,9 @@ six==1.16.0
     #   python-dateutil
     #   requests-mock
     #   w3lib
-smmap==5.0.0
+smmap==5.0.1
     # via gitdb
-soupsieve==2.4.1
+soupsieve==2.5
     # via beautifulsoup4
 sqlparse==0.4.4
     # via django
@@ -192,9 +194,9 @@ tomli==2.0.1
     #   pip-tools
     #   pyproject-hooks
     #   pytest
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via asgiref
-urllib3==1.26.16
+urllib3==1.26.18
     # via
     #   -r requirements.in
     #   directory-validators
@@ -202,10 +204,12 @@ urllib3==1.26.16
     #   sentry-sdk
 w3lib==1.22.0
     # via directory-client-core
-wheel==0.41.1
+wheel==0.41.2
     # via pip-tools
 whitenoise==6.4.0
     # via -r requirements.in
+zipp==3.17.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
Bump urllib3 to 1.26.18

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1338
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Upgraded any vulnerable dependencies.
- [x] Python requirements have been re-compiled.
- [x] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
